### PR TITLE
The tweet is now a link to the article, not the main website.

### DIFF
--- a/balzac/article.php
+++ b/balzac/article.php
@@ -16,7 +16,7 @@
     
         <?php echo article_markdown(); ?>
           
-        <a href="http://twitter.com/share?url=<?php echo full_url(); ?>&text=<?php echo article_title(); ?>&via=<?php echo twitter_account(); ?>" class="share">Share</a>
+        <a href="http://twitter.com/share?url=<?php echo (full_url() . article_url()); ?>&text=<?php echo article_title(); ?>&via=<?php echo twitter_account(); ?>" class="share">Share</a>
     
       </article>
     </section>


### PR DESCRIPTION
It seems smarter for me, if a user clicks on "Share" at the end of an article he wants to share the article, not the website.
